### PR TITLE
stop wrapping svg in a tag

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -23,9 +23,9 @@ export default function Header() {
   return (
     <header className={clsx(headerStyle)}>
       <div className="sticky top-0 max-w-5xl mx-auto flex flex-row justify-start items-center space-x-4">
-        <a className={clsx(loaded && 'bg-[#fff5f6]', 'w-20 h-20 rounded-full transition duration-1000 delay-500')} href="https://icon.object1037.dev" target="_blank" rel="noopener noreferrer" aria-label='icon'>
-          <Icon className={clsx(loaded ? 'fill-[#ffbac1] stroke-black' : 'dark:stroke-white fill-transparent', "w-[4.8rem] h-[4.8rem] m-[0.1rem] transition duration-1000 delay-500")}/>
-        </a>
+        <div onClick={() => location.href = 'https://icon.object1037.dev'} className={clsx(loaded && 'bg-[#fff5f6]', 'w-20 h-20 rounded-full transition duration-1000 delay-500')}>
+          <Icon className={clsx(loaded ? 'fill-[#ffbac1] stroke-gray-900' : 'dark:stroke-white fill-transparent', "w-[4.8rem] h-[4.8rem] m-[0.1rem] transition duration-1000 delay-500")}/>
+        </div>
         <h1 className="font-semibold text-2xl m-2">object1037</h1>
       </div>
     </header>


### PR DESCRIPTION
Safariでtransitionが効かなくなるため